### PR TITLE
Add linter support for ALE vim plugin.

### DIFF
--- a/ale_linters/beancount/bean_check.vim
+++ b/ale_linters/beancount/bean_check.vim
@@ -1,0 +1,7 @@
+call ale#linter#Define('beancount', {
+\   'name': 'bean_check',
+\   'output_stream': 'stderr',
+\   'executable': 'bean-check',
+\   'command': 'bean-check %s',
+\   'callback': 'ale#handlers#HandleUnixFormatAsError',
+\})


### PR DESCRIPTION
ALE is a syntax checker similar to Syntastic, but support async in
Vim8 and NeoVim.